### PR TITLE
add piecewise logistic growth with constant capacity

### DIFF
--- a/src/timeseers/__init__.py
+++ b/src/timeseers/__init__.py
@@ -1,8 +1,10 @@
 from timeseers.linear_trend import LinearTrend
 from timeseers.timeseries_model import TimeSeriesModel
 from timeseers.fourier_seasonality import FourierSeasonality
+from timeseers.logistic_growth import LogisticGrowth
 from timeseers.indicator import Indicator
-from timeseers.constant import  Constant
+from timeseers.constant import Constant
 from timeseers.regressor import Regressor
 
-__all__ = ["LinearTrend", "TimeSeriesModel", "FourierSeasonality", "Indicator", "Constant", "Regressor"]
+__all__ = ["LinearTrend", "TimeSeriesModel", "FourierSeasonality", "Indicator",
+           "Constant", "Regressor", "LogisticGrowth"]

--- a/src/timeseers/logistic_growth.py
+++ b/src/timeseers/logistic_growth.py
@@ -1,0 +1,121 @@
+import numpy as np
+import theano.tensor as T
+import theano
+from timeseers.timeseries_model import TimeSeriesModel
+from timeseers.utils import add_subplot, get_group_definition
+import pymc3 as pm
+
+
+class LogisticGrowth(TimeSeriesModel):
+    def __init__(
+            self, capacity: float, name: str = None, n_changepoints=None,
+            changepoints_prior_scale=0.05, growth_prior_scale=1, pool_cols=None,
+            pool_type='complete'
+    ):
+        self.cap = capacity
+        self.n_changepoints = n_changepoints
+        self.changepoints_prior_scale = changepoints_prior_scale
+        self.growth_prior_scale = growth_prior_scale
+        self.pool_cols = pool_cols
+        self.pool_type = pool_type
+        self.name = name or f"LogisticGrowth(n_changepoints={n_changepoints})"
+        super().__init__()
+
+    def definition(self, model, X, scale_factor):
+
+        def update_gamma(j, gamma, i, delta, offset, rate, change_point):
+            return T.set_subtensor(
+                gamma[i, j],
+                (change_point[j] - offset[i] - T.sum(gamma[i, :j])) *
+                (1 - (rate[i] + T.sum(delta[i, :j])) / (rate[i] + T.sum(delta[i, :j+1])))
+                )
+
+        def get_gamma(i, gamma_init, delta, m, k, s):
+            gamma, _ = theano.scan(
+              update_gamma,
+              sequences=[
+                  T.arange(gamma_init.shape[1]),
+              ],
+              outputs_info=gamma_init,
+              non_sequences=[i, delta, m, k, s],
+            )
+            return gamma[-1]
+
+        t = X["t"].values
+        self.cap_scaled = self._y_scaler_.transform(self.cap)
+        group, n_groups, self.groups_ = get_group_definition(X, self.pool_cols, self.pool_type)
+        self.s = np.linspace(0, np.max(t), self.n_changepoints + 2)[1:-1]
+
+        with model:
+            A = (t[:, None] > self.s) * 1.0
+
+            if self.pool_type == 'partial':
+                sigma_k = pm.HalfCauchy(self._param_name('sigma_k'), beta=self.growth_prior_scale)
+                offset_k = pm.Normal(self._param_name('offset_k'), mu=0, sd=1, shape=n_groups)
+                k = pm.Deterministic(self._param_name("k"), offset_k * sigma_k)
+
+                sigma_delta = pm.HalfCauchy(
+                    self._param_name('sigma_delta'), beta=self.changepoints_prior_scale
+                )
+                offset_delta = pm.Laplace(
+                    self._param_name('offset_delta'), 0, 1, shape=(n_groups, self.n_changepoints)
+                )
+                delta = pm.Deterministic(self._param_name("delta"), offset_delta * sigma_delta)
+
+            else:
+                delta = pm.Laplace(self._param_name("delta"), 0, self.changepoints_prior_scale,
+                                   shape=(n_groups, self.n_changepoints))
+                k = pm.Normal(self._param_name("k"), 0, self.growth_prior_scale,
+                              shape=n_groups, testval=np.ones(n_groups))
+
+            m = pm.Normal(self._param_name("m"), 0, 5, shape=n_groups)
+
+            gamma_init = T.zeros_like(delta)
+            gamma, _ = theano.scan(
+                get_gamma,
+                sequences=[T.arange(gamma_init.shape[0])],
+                outputs_info=gamma_init,
+                non_sequences=[delta, m, k, self.s],
+            )
+            gamma = gamma[-1]
+            growth = (
+                (k[group] + pm.math.sum(A * delta[group], axis=1)) *
+                (t - (m[group] + pm.math.sum(A * gamma[group], axis=1)))
+            )
+            growth = self.cap_scaled / (1 + pm.math.exp(-growth))
+        return growth
+
+    def _predict(self, trace, t, pool_group=0):
+
+        delta = trace[self._param_name("delta")][:, pool_group]
+        k = trace[self._param_name("k")][:, pool_group]
+        m = trace[self._param_name("m")][:, pool_group]
+
+        A = (t[:, None] > self.s) * 1
+        gamma = np.zeros(delta.T.shape)
+        for i in range(gamma.shape[0]):
+            gamma[i] = (
+                (self.s[i] - m - gamma[:i].sum(axis=0)) *
+                (1 - ((k + delta[:, :i].sum(axis=1)) / (k + delta[:, :i+1].sum(axis=1)))).T
+            )
+        g = (
+            (k + A @ delta.T) *
+            (t[:, None] - (m + A @ gamma))
+        )
+        return self.cap_scaled / (1 + np.exp(-g))
+
+    def plot(self, trace, scaled_t, y_scaler):
+        ax = add_subplot()
+        ax.set_title(str(self))
+        ax.set_xticks([])
+        growth_return = np.empty((len(scaled_t), len(self.groups_)))
+        for group_code, group_name in self.groups_.items():
+            scaled_growth = self._predict(trace, scaled_t, group_code)
+            growth = y_scaler.inv_transform(scaled_growth)
+            ax.plot(scaled_t, growth.mean(axis=1), label=group_name)
+            growth_return[:, group_code] = scaled_growth.mean(axis=1)
+
+        for changepoint in self.s:
+            ax.axvline(changepoint, linestyle="--", alpha=0.2, c="k")
+        ax.legend()
+        return growth_return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,14 @@ def trend_data(request):
 
 
 @pytest.fixture(params=[1, 5, 10])
+def logistic_growth_data(request):
+    np.random.seed(42)
+    n_changepoints = request.param
+    data, delta = utils.logistic_growth_data(n_changepoints, noise=0.0001)
+    return data, delta, n_changepoints
+
+
+@pytest.fixture(params=[1, 5, 10])
 def seasonal_data(request):
     np.random.seed(42)
     n_components = request.param

--- a/tests/test_logistic_growth.py
+++ b/tests/test_logistic_growth.py
@@ -1,0 +1,11 @@
+from timeseers import LogisticGrowth
+from timeseers.utils import MaxScaler
+import numpy as np
+
+
+def test_can_fit_generated_data(logistic_growth_data):
+    data, true_delta, n_changepoints = logistic_growth_data
+    model = LogisticGrowth(capacity=1, n_changepoints=n_changepoints)
+    model.fit(data, data["value"], cores=1, chains=1, y_scaler=MaxScaler)
+    model_delta = model.trace_[model._param_name("delta")].mean(axis=0)[0]
+    np.testing.assert_allclose(model_delta, true_delta, atol=0.01)


### PR DESCRIPTION
Closes #2 
Added piecewise logistic growth and tested with some data. I have tested with the example data at [prophet docs](https://facebook.github.io/prophet/docs/saturating_forecasts.html)
- I had to add a MaxScaler to get the model working properly. I am not sure if it's okay. Fbprophet does something like this:
```
        if self.growth == 'logistic' and 'floor' in df:
            self.logistic_floor = True
            floor = df['floor']
        else:
            floor = 0.
        self.y_scale = (df['y'] - floor).abs().max()

        if 'y' in df:
            df['y_scaled'] = (df['y'] - df['floor']) / self.y_scale
```

- I have added a test case following other examples.
- Currently we have a constant capacity and no floor.