### PR TITLE
Allow model extension with arbitrary likelihood

### DIFF
--- a/src/timeseers/likelihood.py
+++ b/src/timeseers/likelihood.py
@@ -1,0 +1,32 @@
+from abc import ABC, abstractmethod
+import pymc3 as pm
+
+
+class Likelihood(ABC):
+    """Subclasses should implement the observed method which defines an observed random variable"""
+    @abstractmethod
+    def observed(self, mu, y_scaled):
+        pass
+
+
+class Gaussian(Likelihood):
+    """Gaussian likelihood with constant variance"""
+    def __init__(self, sigma=0.5):
+        self.sigma = sigma
+
+    def observed(self, mu, y_scaled):
+        sigma = pm.HalfCauchy("sigma", self.sigma)
+        pm.Normal("obs", mu=mu, sd=sigma, observed=y_scaled)
+
+
+class StudentT(Likelihood):
+    """StudentT likelihood with constant variance, robust to outliers"""
+    def __init__(self, alpha=1., beta=1., sigma=0.5):
+        self.alpha = alpha
+        self.beta = beta
+        self.sigma = sigma
+
+    def observed(self, mu, y_scaled):
+        nu = pm.InverseGamma("nu", alpha=self.alpha, beta=self.beta)
+        sigma = pm.HalfCauchy("sigma", self.sigma)
+        pm.StudentT("obs", mu=mu, sd=sigma, nu=nu, observed=y_scaled)


### PR DESCRIPTION
Here's my take on this.

- Add base Likehood class
- Allow users to pass arbitrary likelihood terms as instances of `Likelihood`
- Define Gaussian likelihood and use it as the default
-  Add StudentT likelihood. We might remove this one and expect the users to extend as they please. Or we can create a pool of likelihoods (i.e. negative binomial).

I'm not sure about the variable naming.

Closes #30 