### PR TITLE
fix unit tests

### DIFF
--- a/tests/test_fourier_seasonality.py
+++ b/tests/test_fourier_seasonality.py
@@ -9,6 +9,6 @@ def test_can_fit_generated_data(seasonal_data):
     model.fit(data, data["value"], y_scaler=IdentityScaler, tune=1000, draws=10000)
 
     # No groups, so we can take mean over 1 as well
-    model_beta = np.mean(model.trace_["beta"], axis=(0, 1))
+    model_beta = np.mean(model.trace_[model._param_name("beta")], axis=(0, 1))
 
     np.testing.assert_allclose(model_beta, true_beta, atol=0.12)

--- a/tests/test_linear_trend.py
+++ b/tests/test_linear_trend.py
@@ -7,7 +7,7 @@ def test_can_fit_generated_data(trend_data):
     model = LinearTrend(n_changepoints=n_changepoints)
     model.fit(data, data["value"])
 
-    y_scale_factor = model._y_scaler_.max_ - model._y_scaler_.min_
-    model_delta = np.mean(model.trace_["delta"], axis=0) * y_scale_factor
+    y_scale_factor = model._y_scaler_.std_
+    model_delta = np.mean(model.trace_[model._param_name("delta")], axis=(0, 1)) * y_scale_factor
 
     np.testing.assert_allclose(model_delta, true_delta, atol=0.01)

--- a/tests/test_logistic_growth.py
+++ b/tests/test_logistic_growth.py
@@ -6,6 +6,6 @@ import numpy as np
 def test_can_fit_generated_data(logistic_growth_data):
     data, true_delta, n_changepoints = logistic_growth_data
     model = LogisticGrowth(capacity=1, n_changepoints=n_changepoints)
-    model.fit(data, data["value"], cores=1, chains=1, y_scaler=MaxScaler)
-    model_delta = model.trace_[model._param_name("delta")].mean(axis=0)[0]
+    model.fit(data, data["value"], y_scaler=MaxScaler)
+    model_delta = model.trace_[model._param_name("delta")].mean(axis=(0, 1))
     np.testing.assert_allclose(model_delta, true_delta, atol=0.01)


### PR DESCRIPTION
I went ahead and created a PR. Feel free to reject if you have other plans here.

- y_scale_factor changed to `std_`
- parameter names are updated
- I forgot to remove `cores=1` and `chains=1` from logistic growth test. That might be slowing down.

Closes #35 