### PR TITLE
Sample weight

### DIFF
--- a/src/timeseers/likelihood.py
+++ b/src/timeseers/likelihood.py
@@ -3,7 +3,7 @@ import pymc3 as pm
 
 
 class Likelihood(ABC):
-    """Subclasses should implement the observed method which defines an observed random variable"""
+    """Subclasses should implement the _likelihood_priors method which defines the prior parameters of an observed random variable"""
     @property
     def distribution(self):
         raise NotImplementedError

--- a/src/timeseers/likelihood.py
+++ b/src/timeseers/likelihood.py
@@ -4,29 +4,49 @@ import pymc3 as pm
 
 class Likelihood(ABC):
     """Subclasses should implement the observed method which defines an observed random variable"""
+    @property
+    def distribution(self):
+        raise NotImplementedError
+
+    def observed(self, mu, y_scaled, sample_weight):
+        model_parameters = self.define_priors()
+
+        model_parameters["mu"] = mu
+
+        if sample_weight is None:
+            self.distribution("obs", **model_parameters, observed=y_scaled)
+        else:
+            pm.Potential("obs", sample_weight * self.distribution.dist(**model_parameters).logp(y_scaled))
+
     @abstractmethod
-    def observed(self, mu, y_scaled):
+    def define_priors(self):
         pass
 
 
 class Gaussian(Likelihood):
     """Gaussian likelihood with constant variance"""
+    distribution = pm.Normal
+
     def __init__(self, sigma=0.5):
         self.sigma = sigma
 
-    def observed(self, mu, y_scaled):
-        sigma = pm.HalfCauchy("sigma", self.sigma)
-        pm.Normal("obs", mu=mu, sd=sigma, observed=y_scaled)
+    def define_priors(self):
+        return {
+            "sigma": pm.HalfCauchy("sigma", self.sigma)
+        }
 
 
 class StudentT(Likelihood):
     """StudentT likelihood with constant variance, robust to outliers"""
+    distribution = pm.StudentT
+
     def __init__(self, alpha=1., beta=1., sigma=0.5):
         self.alpha = alpha
         self.beta = beta
         self.sigma = sigma
 
-    def observed(self, mu, y_scaled):
-        nu = pm.InverseGamma("nu", alpha=self.alpha, beta=self.beta)
-        sigma = pm.HalfCauchy("sigma", self.sigma)
-        pm.StudentT("obs", mu=mu, sd=sigma, nu=nu, observed=y_scaled)
+    def define_priors(self):
+        return {
+            "nu": pm.InverseGamma("nu", alpha=self.alpha, beta=self.beta),
+            "sigma": pm.HalfCauchy("sigma", self.sigma)
+        }

--- a/src/timeseers/likelihood.py
+++ b/src/timeseers/likelihood.py
@@ -9,7 +9,7 @@ class Likelihood(ABC):
         raise NotImplementedError
 
     def observed(self, mu, y_scaled, sample_weight):
-        model_parameters = self.define_priors()
+        model_parameters = self._likelihood_priors()
 
         model_parameters["mu"] = mu
 
@@ -19,7 +19,10 @@ class Likelihood(ABC):
             pm.Potential("obs", sample_weight * self.distribution.dist(**model_parameters).logp(y_scaled))
 
     @abstractmethod
-    def define_priors(self):
+    def _likelihood_priors(self):
+        """
+        Dictionary of priors for the observation likelihood. Excludes `mu`
+        """
         pass
 
 
@@ -30,7 +33,7 @@ class Gaussian(Likelihood):
     def __init__(self, sigma=0.5):
         self.sigma = sigma
 
-    def define_priors(self):
+    def _likelihood_priors(self):
         return {
             "sigma": pm.HalfCauchy("sigma", self.sigma)
         }
@@ -45,7 +48,7 @@ class StudentT(Likelihood):
         self.beta = beta
         self.sigma = sigma
 
-    def define_priors(self):
+    def _likelihood_priors(self):
         return {
             "nu": pm.InverseGamma("nu", alpha=self.alpha, beta=self.beta),
             "sigma": pm.HalfCauchy("sigma", self.sigma)

--- a/src/timeseers/timeseries_model.py
+++ b/src/timeseers/timeseries_model.py
@@ -6,7 +6,7 @@ import numpy as np
 from abc import ABC, abstractmethod
 
 def _check_sample_weight(sample_weight, X):
-    if sample_weight is None:
+    if sample_weight is None or (min(sample_weight) == max(sample_weight)):
         return None
 
     n_samples = len(X)

--- a/src/timeseers/timeseries_model.py
+++ b/src/timeseers/timeseries_model.py
@@ -6,7 +6,7 @@ import numpy as np
 from abc import ABC, abstractmethod
 
 def _check_sample_weight(sample_weight, X):
-    if sample_weight is None or (min(sample_weight) == max(sample_weight)):
+    if min(sample_weight) == max(sample_weight):
         return None
 
     n_samples = len(X)
@@ -30,7 +30,8 @@ class TimeSeriesModel(ABC):
         if not X.index.is_monotonic_increasing:
             raise ValueError('index of X is not monotonically increasing. You might want to call `.reset_index()`')
 
-        sample_weight = _check_sample_weight(sample_weight, X)
+        if sample_weight is not None:
+            sample_weight = _check_sample_weight(sample_weight, X)
 
         X_to_scale = X.select_dtypes(exclude='category')
         self._X_scaler_ = X_scaler()

--- a/src/timeseers/timeseries_model.py
+++ b/src/timeseers/timeseries_model.py
@@ -26,7 +26,7 @@ class TimeSeriesModel(ABC):
         if likelihood is None:
             likelihood = Gaussian()
         with model:
-            likelihood.observed(mu, y_scaled, sample_weight=sample_weight)
+            likelihood.observed(mu, y_scaled.values, sample_weight=sample_weight)
             self.trace_ = pm.sample(**sample_kwargs)
 
     def plot_components(self, X_true=None, y_true=None, groups=None, fig=None):

--- a/src/timeseers/timeseries_model.py
+++ b/src/timeseers/timeseries_model.py
@@ -7,7 +7,7 @@ from abc import ABC, abstractmethod
 
 
 class TimeSeriesModel(ABC):
-    def fit(self, X, y, X_scaler=MinMaxScaler, y_scaler=StdScaler, likelihood=None, **sample_kwargs):
+    def fit(self, X, y, sample_weight=None, X_scaler=MinMaxScaler, y_scaler=StdScaler, likelihood=None, **sample_kwargs):
         if not X.index.is_monotonic_increasing:
             raise ValueError('index of X is not monotonically increasing. You might want to call `.reset_index()`')
 
@@ -26,7 +26,7 @@ class TimeSeriesModel(ABC):
         if likelihood is None:
             likelihood = Gaussian()
         with model:
-            likelihood.observed(mu, y_scaled)
+            likelihood.observed(mu, y_scaled, sample_weight=sample_weight)
             self.trace_ = pm.sample(**sample_kwargs)
 
     def plot_components(self, X_true=None, y_true=None, groups=None, fig=None):

--- a/src/timeseers/utils.py
+++ b/src/timeseers/utils.py
@@ -96,6 +96,26 @@ def add_subplot(height=5):
     fig.set_size_inches(w, h + height)
     return fig.add_subplot(len(fig.axes) + 1, 1, len(fig.axes) + 1)
 
+def weighted_data(sigmas=[1, 2], weights=[1, 2]):
+    t = np.linspace(0, 1, 1000)
+
+    constant = np.concatenate(
+        [
+            np.random.randn(500) * sigmas[0],
+            np.random.randn(500) * sigmas[1]
+        ],
+        axis=None
+    )
+    sample_weight = np.concatenate(
+        [
+            np.repeat(weights[0], 500),
+            np.repeat(weights[1], 500)
+        ],
+        axis=None
+    )
+
+    return pd.DataFrame({"t": pd.date_range("2018-1-1", periods=len(t)), "value": constant, "weight": sample_weight})
+
 
 def trend_data(n_changepoints, location="spaced", noise=0.001):
     delta = np.random.laplace(size=n_changepoints)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-import pandas as pd
 import numpy as np
 import pytest
 from timeseers import utils

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import pandas as pd
 import numpy as np
 import pytest
 from timeseers import utils
@@ -25,3 +26,12 @@ def seasonal_data(request):
     n_components = request.param
     data, beta = utils.seasonal_data(n_components, noise=0.0000000001)
     return data, beta, n_components
+
+
+@pytest.fixture(params=[[1, 1], [1, 2], [1, 5]])
+def weighted_data(request):
+    np.random.seed(42)
+    weights = request.param
+
+    data = utils.weighted_data(weights=weights)
+    return data

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -1,0 +1,33 @@
+import pandas as pd
+import numpy as np
+
+from timeseers import Constant
+from timeseers.utils import IdentityScaler
+
+def weighted_sigma(y, sample_weight):
+    n_observations = len(y)
+    m_w = weighted_mean(y, sample_weight)
+
+    num = (y - m_w) ** 2
+    num *= sample_weight
+    num = num.sum()
+
+    den = (n_observations - 1) * sample_weight.sum() / n_observations
+
+    return np.sqrt(num / den)
+
+
+def weighted_mean(y, sample_weight):
+    return (y * sample_weight).sum() / sample_weight.sum()
+
+
+def test_weights(weighted_data):
+    df = weighted_data
+
+    model = Constant(name="intercept", lower=-1, upper=1)
+    model.fit(df[["t"]], df["value"], sample_weight=df['weight'], y_scaler=IdentityScaler, tune=2000)
+
+    sigma_estimate = model.trace_["sigma"].mean()
+    sigma_true = weighted_sigma(df["value"], df["weight"])
+
+    np.testing.assert_allclose(sigma_estimate, sigma_true, atol=.01)

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -2,7 +2,7 @@ import pandas as pd
 import numpy as np
 
 from timeseers import Constant
-from timeseers.utils import IdentityScaler
+from timeseers import utils
 
 def weighted_sigma(y, sample_weight):
     n_observations = len(y)
@@ -21,13 +21,31 @@ def weighted_mean(y, sample_weight):
     return (y * sample_weight).sum() / sample_weight.sum()
 
 
-def test_weights(weighted_data):
+def test_can_fit_generated_data(weighted_data):
     df = weighted_data
 
-    model = Constant(name="intercept", lower=-1, upper=1)
-    model.fit(df[["t"]], df["value"], sample_weight=df['weight'], y_scaler=IdentityScaler, tune=2000)
+    model = Constant(lower=-1, upper=1)
+    model.fit(df[["t"]], df["value"], sample_weight=df['weight'], y_scaler=utils.IdentityScaler, tune=2000)
 
     sigma_estimate = model.trace_["sigma"].mean()
     sigma_true = weighted_sigma(df["value"], df["weight"])
 
     np.testing.assert_allclose(sigma_estimate, sigma_true, atol=.01)
+
+
+def test_generated_data_parameter_change():
+    df_lower_weights = utils.weighted_data(weights=[1, 2])
+    # Higher weight on larger sigma data
+    df_higher_weights = utils.weighted_data(weights=[1, 5])
+
+    model_lower = Constant(lower=-1, upper=1)
+    model_higher = Constant(lower=-1, upper=1)
+
+    model_lower.fit(df_lower_weights[["t"]],
+    df_lower_weights["value"], sample_weight=df_lower_weights['weight'], y_scaler=utils.IdentityScaler, tune=2000)
+    model_higher.fit(df_higher_weights[["t"]], df_higher_weights["value"], sample_weight=df_higher_weights['weight'], y_scaler=utils.IdentityScaler, tune=2000)
+
+    sigma_lower = model_lower.trace_["sigma"].mean()
+    sigma_higher = model_higher.trace_["sigma"].mean()
+
+    assert sigma_lower < sigma_higher

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -1,4 +1,3 @@
-import pandas as pd
 import numpy as np
 
 from timeseers import Constant


### PR DESCRIPTION
The weighted regression is implemented via `pm.Potential` and the logp method for each `pymc3` distribution. To implement, added `define_priors` abstract method to generalize the previous abstract `observed` method. 

The `sample_weight` argument is added to the `fit` method of `TimeSeriesModel` in the same format as sklearn arguments.

Currently working through tests. 