### PR TITLE
Add RBFSeasonality

### DIFF
--- a/src/timeseers/__init__.py
+++ b/src/timeseers/__init__.py
@@ -1,10 +1,11 @@
 from timeseers.linear_trend import LinearTrend
 from timeseers.timeseries_model import TimeSeriesModel
 from timeseers.fourier_seasonality import FourierSeasonality
+from timeseers.rbf_seasonality import RBFSeasonality
 from timeseers.logistic_growth import LogisticGrowth
 from timeseers.indicator import Indicator
 from timeseers.constant import Constant
 from timeseers.regressor import Regressor
 
 __all__ = ["LinearTrend", "TimeSeriesModel", "FourierSeasonality", "Indicator",
-           "Constant", "Regressor", "LogisticGrowth"]
+           "Constant", "Regressor", "LogisticGrowth", "RBFSeasonality"]

--- a/src/timeseers/rbf_seasonality.py
+++ b/src/timeseers/rbf_seasonality.py
@@ -2,15 +2,7 @@ import numpy as np
 import pandas as pd
 import pymc3 as pm
 from timeseers.timeseries_model import TimeSeriesModel
-from timeseers.utils import add_subplot, get_group_definition
-
-
-
-def get_periodic_peaks(
-        n: int = 20,
-        period: pd.Timedelta = pd.Timedelta(days=365.25)):
-    """Returns n periodic peaks that repeats each period"""
-    return np.array([period * i / n for i in range(n)])
+from timeseers.utils import add_subplot, get_group_definition, get_periodic_peaks
 
 
 class RBFSeasonality(TimeSeriesModel):
@@ -30,7 +22,10 @@ class RBFSeasonality(TimeSeriesModel):
         sigma=0.1,
         pool_type='complete'
     ):
-        self.peaks = peaks or get_periodic_peaks(period=period)
+        if peaks is None:
+            self.peaks = get_periodic_peaks(period=period)
+        else:
+            self.peaks = peaks
         self.period = period
         self.shrinkage_strength = shrinkage_strength
         self.sigma = sigma

--- a/src/timeseers/rbf_seasonality.py
+++ b/src/timeseers/rbf_seasonality.py
@@ -1,0 +1,79 @@
+import numpy as np
+import pandas as pd
+import pymc3 as pm
+from timeseers.timeseries_model import TimeSeriesModel
+from timeseers.utils import add_subplot, get_group_definition
+
+
+class RBFSeasonality(TimeSeriesModel):
+    def __init__(
+        self,
+        peaks,
+        name: str = None,
+        period: pd.Timedelta = pd.Timedelta(days=365.25),
+        shrinkage_strength=100,
+        pool_cols=None,
+        sigma=0.2,
+        pool_type='complete'
+    ):
+        self.peaks = peaks
+        self.period = period
+        self.shrinkage_strength = shrinkage_strength
+        self.sigma = sigma
+        self.pool_cols = pool_cols
+        self.pool_type = pool_type
+        self.name = name or f"RBFSeasonality(period={self.period})"
+        super().__init__()
+
+
+    @staticmethod
+    def _X_t(t, periods, p, sigma, year):
+        year = year / p
+        mod = (t % year)[:, None]
+        left_difference = np.sqrt( (mod - periods[None, :]) **2 )
+        right_difference = np.abs(year - left_difference)
+        return  np.exp(- ((np.minimum(left_difference, right_difference)) ** 2) / (2 * sigma**2))
+
+    def definition(self, model, X, scale_factor):
+        t = X["t"].values
+        group, n_groups, self.groups_ = get_group_definition(X, self.pool_cols, self.pool_type)
+        self.p_ = self.period / scale_factor['t']
+        self.peaks_ = self.peaks / scale_factor['t']
+        n_params = len(self.peaks)
+        self.factor_ = scale_factor["t"]
+        with model:
+            if self.pool_type == 'partial':
+
+                mu_beta = pm.Normal(self._param_name("mu_beta"), mu=0, sigma=1, shape=n_params)  # TODO: add as parameters
+                sigma_beta = pm.HalfNormal(self._param_name("sigma_beta"), 0.1, shape=n_params)
+                offset_beta = pm.Normal(self._param_name("offset_beta"), 0, 1 / self.shrinkage_strength, shape=(n_groups, n_params))
+
+                beta = pm.Deterministic(self._param_name("beta"), mu_beta + offset_beta * sigma_beta)
+            else:
+                beta = pm.Normal(self._param_name("beta"), 0, 1, shape=(n_groups, n_params))
+
+            seasonality = pm.math.sum(self._X_t(t, self.peaks_, self.factor_, self.sigma, self.period) * beta[group], axis=1)
+
+        return seasonality
+
+    def _predict(self, trace, t, pool_group=0):
+        return self._X_t(t, self.peaks_, self.factor_, self.sigma, self.period) @ trace[self._param_name("beta")][:, pool_group].T
+
+    def plot(self, trace, scaled_t, y_scaler):
+        ax = add_subplot()
+        ax.set_title(str(self))
+
+        seasonality_return = np.empty((len(scaled_t), len(self.groups_)))
+        for group_code, group_name in self.groups_.items():
+            scaled_s = self._predict(trace, scaled_t, group_code)
+            s = y_scaler.inv_transform(scaled_s)
+            ax.plot(list(range(self.period.days)), s.mean(axis=1)[:self.period.days], label=group_name)
+
+            seasonality_return[:, group_code] = scaled_s.mean(axis=1)
+
+        return seasonality_return
+
+    def __repr__(self):
+        return f"RBFSeasonality(n={self.period}, " \
+               f"pool_cols={self.pool_cols}, " \
+               f"pool_type={self.pool_type}"

--- a/src/timeseers/rbf_seasonality.py
+++ b/src/timeseers/rbf_seasonality.py
@@ -38,9 +38,9 @@ class RBFSeasonality(TimeSeriesModel):
     @staticmethod
     def _X_t(t, peaks, sigma, year):
         mod = (t % year)[:, None]
-        left_difference = np.sqrt( (mod - peaks[None, :]) **2 )
+        left_difference = np.sqrt((mod - peaks[None, :]) **2)
         right_difference = np.abs(year - left_difference)
-        return  np.exp(- ((np.minimum(left_difference, right_difference)) ** 2) / (2 * sigma**2))
+        return  np.exp(-((np.minimum(left_difference, right_difference)) ** 2) / (2 * sigma**2))
 
     def definition(self, model, X, scale_factor):
         t = X["t"].values

--- a/src/timeseers/rbf_seasonality.py
+++ b/src/timeseers/rbf_seasonality.py
@@ -34,13 +34,12 @@ class RBFSeasonality(TimeSeriesModel):
         self.name = name or f"RBFSeasonality(period={self.period})"
         super().__init__()
 
-
     @staticmethod
     def _X_t(t, peaks, sigma, year):
         mod = (t % year)[:, None]
-        left_difference = np.sqrt((mod - peaks[None, :]) **2)
+        left_difference = np.sqrt((mod - peaks[None, :]) ** 2)
         right_difference = np.abs(year - left_difference)
-        return  np.exp(-((np.minimum(left_difference, right_difference)) ** 2) / (2 * sigma**2))
+        return np.exp(-((np.minimum(left_difference, right_difference)) ** 2) / (2 * sigma**2))
 
     def definition(self, model, X, scale_factor):
         t = X["t"].values
@@ -52,9 +51,10 @@ class RBFSeasonality(TimeSeriesModel):
         with model:
             if self.pool_type == 'partial':
 
-                mu_beta = pm.Normal(self._param_name("mu_beta"), mu=0, sigma=1, shape=n_params)  # TODO: add as parameters
+                mu_beta = pm.Normal(self._param_name("mu_beta"), mu=0, sigma=1, shape=n_params)
                 sigma_beta = pm.HalfNormal(self._param_name("sigma_beta"), 0.1, shape=n_params)
-                offset_beta = pm.Normal(self._param_name("offset_beta"), 0, 1 / self.shrinkage_strength, shape=(n_groups, n_params))
+                offset_beta = pm.Normal(
+                    self._param_name("offset_beta"), 0, 1 / self.shrinkage_strength, shape=(n_groups, n_params))
 
                 beta = pm.Deterministic(self._param_name("beta"), mu_beta + offset_beta * sigma_beta)
             else:

--- a/src/timeseers/rbf_seasonality.py
+++ b/src/timeseers/rbf_seasonality.py
@@ -10,7 +10,7 @@ class RBFSeasonality(TimeSeriesModel):
     Seasonality with radial basis functions. Periodic radial basis functions
     are placed to model seasonality. With ``peaks`` argument, RBF's can be placed
     arbitrarily. If peaks is not provided, 20 evenly placed RBF's are used with
-    a period of 365.25 days.
+    evenly spread out over `period` days
     """
     def __init__(
         self,

--- a/src/timeseers/rbf_seasonality.py
+++ b/src/timeseers/rbf_seasonality.py
@@ -9,7 +9,7 @@ class RBFSeasonality(TimeSeriesModel):
     """
     Seasonality with radial basis functions. Periodic radial basis functions
     are placed to model seasonality. With ``peaks`` argument, RBF's can be placed
-    arbitrarily. If peaks is not provided, 20 evenly placed RBF's are used with
+    arbitrarily. If peaks is not provided, 20 evenly placed RBF's are used 
     evenly spread out over `period` days
     """
     def __init__(

--- a/src/timeseers/utils.py
+++ b/src/timeseers/utils.py
@@ -173,9 +173,10 @@ def seasonal_data(n_components, noise=0.001):
 def rbf_seasonal_data(n_components, sigma=0.015, noise=0.001):
     def X(t, peaks, sigma, year):
         mod = (t % year)[:, None]
-        left_difference = np.sqrt( (mod - peaks[None, :]) **2 )
+        left_difference = np.sqrt((mod - peaks[None, :]) ** 2)
         right_difference = np.abs(year - left_difference)
-        return  np.exp(- ((np.minimum(left_difference, right_difference)) ** 2) / (2 * sigma**2))
+        return np.exp(- ((np.minimum(left_difference, right_difference)) ** 2) / (2 * sigma**2))
+
     t = pd.Series(pd.date_range("2010-01-01", "2014-01-01"))
     scaler = MinMaxScaler()
     scaled_t = scaler.fit_transform(t)
@@ -183,8 +184,8 @@ def rbf_seasonal_data(n_components, sigma=0.015, noise=0.001):
     beta = np.random.normal(size=n_components)
     peaks = get_periodic_peaks(n_components)
     peaks = np.array([p / scale_factor for p in peaks])
-    seasonality = X(scaled_t, peaks, sigma, pd.Timedelta(days=365.25) / scale_factor) @ beta + np.random.randn(len(t)) * noise
-    seasonality_scaled = MinMaxScaler().fit_transform(seasonality)
+    period = pd.Timedelta(days=365.25)
+    seasonality = X(scaled_t, peaks, sigma, period / scale_factor) @ beta + np.random.randn(len(t)) * noise
     return (
         pd.DataFrame(
             {"t": pd.date_range("2018-1-1", periods=len(t)), "value": seasonality}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,3 +25,11 @@ def seasonal_data(request):
     n_components = request.param
     data, beta = utils.seasonal_data(n_components, noise=0.0000000001)
     return data, beta, n_components
+
+
+@pytest.fixture(params=[1, 5, 10])
+def rbf_seasonal_data(request):
+    np.random.seed(42)
+    n_components = request.param
+    data, beta = utils.rbf_seasonal_data(n_components, noise=0.0000000001)
+    return data, beta, n_components

--- a/tests/test_rbf_seasonality.py
+++ b/tests/test_rbf_seasonality.py
@@ -1,0 +1,14 @@
+import numpy as np
+import pandas as pd
+
+from timeseers import RBFSeasonality
+from timeseers.utils import IdentityScaler, get_periodic_peaks
+
+
+def test_can_fit_generated_data(rbf_seasonal_data):
+    data, true_beta, n_components = rbf_seasonal_data
+    ps = get_periodic_peaks(n_components)
+    model = RBFSeasonality(peaks=ps, period=pd.Timedelta(days=365.25), sigma=0.015)
+    model.fit(data[['t']], data['value'], tune=1000, draws=10000, y_scaler=IdentityScaler)
+    model_beta = np.mean(model.trace_[model._param_name("beta")], axis=(0, 1))
+    np.testing.assert_allclose(model_beta, true_beta, atol=0.12)


### PR DESCRIPTION
Closes #39

Add `RBFSeasonality` class and its tests. One might directly specify the peaks by passing `peaks` argument. Otherwise default peaks are obtained by evenly placing 20 peaks in a single period. I have also added `rbf_seasonal_data` utility for testing purposes.

I have tried running it with `seasonal_data` and `rbf_seasonal_data`. Both seems fine. I have also tested it some real sales data (both with partial pooling and complete pooling). It seems to perform well especially with highly seasonal series (such as fruit sales). I hope I can share such plots in the future.

Here is a sample of peaks (features):

![peaks](https://user-images.githubusercontent.com/36677585/136277454-38d09dd9-a11c-4667-ba40-162bac517bc9.png)

Code to reproduce:

```
import pandas as pd
import numpy as np
from matplotlib import pyplot as plt
from timeseers.utils import MinMaxScaler


def _X_t(t, periods, p, sigma, year):
    year = year / p
    mod = (t % year)[:, None]
    left_difference = np.sqrt( (mod - periods[None, :]) **2 )
    right_difference = np.abs(year - left_difference)
    return  np.exp(- ((np.minimum(left_difference, right_difference)) ** 2) / (2 * sigma**2))

t = pd.Series(pd.date_range("2010-01-01", "2014-01-01"))
scaler = MinMaxScaler()
scaled_t = scaler.fit_transform(t)
periods = [pd.Timedelta(days=i * 18.2625) for i in range(20)]
periods_ = [p / scaler.scale_factor_ for p in periods]
periods_ = np.array(periods_)
scale_factor = t.max() - t.min()
res = _X_t(scaled_t, periods_, scaler.scale_factor_, sigma=0.01, year=pd.Timedelta(days=365.25))
plt.figure(figsize=(24,10))
plt.plot(res);

```

Here is a fit when the data is obtained with seasonal_data utility:

![seasonal_fit](https://user-images.githubusercontent.com/36677585/136277943-55d82335-c788-4a19-96b1-d8b1cd201bd1.png)

Code to reproduce:

```
from timeseers import RBFSeasonality
from timeseers.utils import seasonal_data, MinMaxScaler
import pandas as pd
import numpy as np

df, _ = seasonal_data(5)
periods = [pd.Timedelta(days=i * 18.2625) for i in range(20)]

pers = np.array(periods)
model = RBFSeasonality(period=pd.Timedelta(days=365.25), sigma=0.01)
model.fit(df[['t']], df['value'], tune=2000, y_scaler=MinMaxScaler)
model.plot_components(X_true=df, y_true=df['value']);
```

Here is a sample fit with rbf_seasonal_data:

![rbf_seasonal_fit](https://user-images.githubusercontent.com/36677585/136278352-44519b97-54ff-42e2-a663-d97e4d101733.png)

Code to reproduce:

```
import pandas as pd

from timeseers.utils import MinMaxScaler, get_periodic_peaks, rbf_seasonal_data
from timeseers import RBFSeasonality

df, _ = rbf_seasonal_data(5)
ps = get_periodic_peaks(10)
period = pd.Timedelta(days=365.25)
model = RBFSeasonality(peaks=ps, period=period, sigma=0.015)
model.fit(df[['t']], df['value'], tune=2000, y_scaler=MinMaxScaler)
model.plot_components(X_true=df, y_true=df['value']);
```

Not sure about the API, maybe you can point me towards some improvements.